### PR TITLE
use omerbenamram/winstructs instead of forensicmatt/r-winstructs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rwinreg"
-version = "0.2.0-janstarke.1"
+version = "0.2.0-janstarke.2"
 authors = ["Matthew Seyer <https://github.com/forensicmatt/r-winreg>"]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ serde_json = "1.0"
 trace-error = "0.1.5"
 bitflags = "1.0"
 seek_bufread = "~1.2"
+thiserror = "1.0"
 winstructs = {git = "https://github.com/janstarke/winstructs", branch="feature/serialize", version="0.3.1-alpha.0-janstarke.1"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rwinreg"
-version = "0.2.0"
+version = "0.2.0-janstarke.1"
 authors = ["Matthew Seyer <https://github.com/forensicmatt/r-winreg>"]
 
 [lib]
@@ -12,14 +12,9 @@ log = "0.3"
 env_logger = "0.3"
 byteorder = "1"
 encoding = "0.2"
-serde = "0.9"
-serde_derive = "0.9"
-serde_json = "0.9"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 trace-error = "0.1.5"
 bitflags = "1.0"
 seek_bufread = "~1.2"
-
-[dependencies.r-winstructs]
-version = "0.3.2"
-branch = "master"
-git = "https://github.com/forensicmatt/r-winstructs"
+winstructs = {git = "https://github.com/janstarke/winstructs", branch="feature/serialize", version="0.3.1-alpha.0-janstarke.1"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rwinreg"
-version = "0.2.0-janstarke.2"
+version = "0.2.0-janstarke.3"
 authors = ["Matthew Seyer <https://github.com/forensicmatt/r-winreg>"]
 
 [lib]

--- a/examples/hive_examples.rs
+++ b/examples/hive_examples.rs
@@ -7,12 +7,12 @@ fn get_root_node() {
 
     let mut hive = match Hive::from_source(file){
         Ok(h) => h,
-        Err(e) => panic!(e)
+        Err(e) => panic!("{}", e)
     };
 
     let node = match hive.get_root_node(){
         Ok(n) => n,
-        Err(e) => panic!(e)
+        Err(e) => panic!("{}", e)
     };
 
     println!("{:?}",node);

--- a/src/baseblock.rs
+++ b/src/baseblock.rs
@@ -1,6 +1,7 @@
-use rwinstructs::timestamp::{WinTimestamp};
+use winstructs::timestamp::{WinTimestamp};
 use byteorder::{ByteOrder,LittleEndian};
 use errors::RegError;
+use serde::Serialize;
 use utils;
 
 #[derive(Serialize,Debug)]
@@ -49,7 +50,7 @@ impl BaseBlock {
         let primary_seq_num = LittleEndian::read_u32(&buffer[4..8]);
         let secondary_seq_num = LittleEndian::read_u32(&buffer[8..12]);
         let last_written = Box::new(
-            WinTimestamp(
+            WinTimestamp::from(
                 LittleEndian::read_u64(&buffer[12..20])
             )
         );
@@ -137,7 +138,7 @@ mod tests {
         assert_eq!(baseblock.signature, 1718052210);
         assert_eq!(baseblock.primary_seq_num, 2810);
         assert_eq!(baseblock.secondary_seq_num, 2809);
-        assert_eq!(baseblock.last_written.0, 130216723045201708);
+        assert_eq!(baseblock.last_written.value(), 130216723045201708);
         assert_eq!(baseblock.major_version, 1);
         assert_eq!(baseblock.minor_version, 3);
         assert_eq!(baseblock.file_type, 0);

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -12,6 +12,7 @@ use serde::ser;
 use std::io::Read;
 use std::io::{Seek,SeekFrom};
 use std::fmt;
+use serde::Serialize;
 
 #[derive(Serialize, Debug)]
 #[serde(untagged)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,6 +5,7 @@ use cell::Cell;
 use std::io::Read;
 use std::io::Seek;
 use std::io::SeekFrom;
+use serde::Serialize;
 
 // db
 #[derive(Serialize, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-use rwinstructs::security::{SecDescError};
+use winstructs::security::{SecDescError};
 use std::string::FromUtf8Error;
 use std::io;
 use std::fmt;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
 use winstructs::security::{SecDescError};
+use winstructs::err::Error;
 use std::string::FromUtf8Error;
 use std::io;
 use std::fmt;
@@ -11,7 +12,8 @@ pub enum ErrorKind {
     Utf16Error,
     FromUtf8Error,
     ValidationError,
-    SecDescParseError
+    SecDescParseError,
+    UnknownAceType
 }
 
 #[derive(Debug)]
@@ -73,6 +75,18 @@ impl From<SecDescError> for RegError {
             message: format!("{:?}",err),
             kind: ErrorKind::SecDescParseError,
             trace: backtrace!()
+        }
+    }
+}
+impl From<Error> for RegError {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::IoError{source} => RegError::from(source),
+            Error::UnknownAceType{ace_type} => Self {
+                message: format!("Unknown AceType: {}", ace_type),
+                kind: ErrorKind::UnknownAceType,
+                trace: backtrace!()
+            }
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,7 +16,7 @@ pub enum ErrorKind {
     UnknownAceType
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub struct RegError {
     pub message: String,
     pub kind: ErrorKind,

--- a/src/hive.rs
+++ b/src/hive.rs
@@ -8,6 +8,7 @@ use errors::RegError;
 use std::fs::File;
 use std::io::Read;
 use std::io::Seek;
+use serde::Serialize;
 
 pub const HBIN_START_OFFSET: u64 = 4096;
 

--- a/src/lf.rs
+++ b/src/lf.rs
@@ -6,6 +6,7 @@ use cell::Cell;
 use cell::CellData;
 use nk::NodeKey;
 use std::io::{Read,Seek};
+use serde::Serialize;
 
 #[derive(Serialize, Debug)]
 struct FastElement(u32,String);

--- a/src/lh.rs
+++ b/src/lh.rs
@@ -5,6 +5,7 @@ use cell::Cell;
 use cell::CellData;
 use nk::NodeKey;
 use std::io::{Read,Seek};
+use serde::Serialize;
 
 #[derive(Serialize, Debug)]
 struct HashElement(u32,u32);

--- a/src/li.rs
+++ b/src/li.rs
@@ -5,6 +5,7 @@ use cell::Cell;
 use cell::CellData;
 use nk::NodeKey;
 use std::io::{Read,Seek};
+use serde::Serialize;
 
 // li
 #[derive(Serialize, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
-#[macro_use] extern crate serde_derive;
 #[macro_use] extern crate trace_error;
 #[macro_use] extern crate bitflags;
 #[macro_use] extern crate log;
 extern crate seek_bufread;
-extern crate rwinstructs;
+extern crate winstructs;
 extern crate byteorder;
 extern crate encoding;
 extern crate serde;

--- a/src/nk.rs
+++ b/src/nk.rs
@@ -1,5 +1,5 @@
 use byteorder::{ByteOrder,LittleEndian};
-use rwinstructs::timestamp::{WinTimestamp};
+use winstructs::timestamp::{WinTimestamp};
 use errors::RegError;
 use hive::HBIN_START_OFFSET;
 use cell::Cell;
@@ -9,6 +9,7 @@ use vk::ValueKeyList;
 use sk::SecurityKey;
 use utils;
 use serde::ser;
+use serde::Serialize;
 use std::io::{Read,Seek};
 use std::fmt;
 
@@ -80,7 +81,7 @@ impl NodeKey {
         let flags = NodeKeyFlags::from_bits_truncate(
             LittleEndian::read_u16(&buffer[2..4])
         );
-        let last_written = WinTimestamp(
+        let last_written = WinTimestamp::from(
             LittleEndian::read_u64(&buffer[4..12])
         );
         let access_bits = LittleEndian::read_u32(&buffer[12..16]);
@@ -289,7 +290,7 @@ mod tests {
 
         assert_eq!(nk.signature, 27502);
         assert_eq!(nk.flags.bits(), 44);
-        assert_eq!(nk.last_written.0, 130269705849853298);
+        assert_eq!(nk.last_written.value(), 130269705849853298);
         assert_eq!(nk.access_bits, 2);
         assert_eq!(nk.offset_parent_key, 1928);
         assert_eq!(nk.num_sub_keys, 13);

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,7 +1,8 @@
 use vk::ValueKey;
 use nk::NodeKey;
-use rwinstructs::security::SecurityDescriptor;
-use rwinstructs::timestamp::{WinTimestamp};
+use winstructs::security::SecurityDescriptor;
+use winstructs::timestamp::{WinTimestamp};
+use serde::Serialize;
 
 #[derive(Serialize,Debug)]
 pub struct Record {

--- a/src/ri.rs
+++ b/src/ri.rs
@@ -5,6 +5,7 @@ use cell::Cell;
 use cell::CellData;
 use nk::NodeKey;
 use std::io::{Read,Seek};
+use serde::Serialize;
 
 // ri
 #[derive(Serialize, Debug)]

--- a/src/sk.rs
+++ b/src/sk.rs
@@ -1,5 +1,4 @@
 use winstructs::security::{SecurityDescriptor};
-use winstructs::err::Error;
 use byteorder::{ByteOrder,LittleEndian};
 use errors::{RegError};
 use std::io::Cursor;

--- a/src/sk.rs
+++ b/src/sk.rs
@@ -1,7 +1,8 @@
-use rwinstructs::security::{SecurityDescriptor};
+use winstructs::security::{SecurityDescriptor};
 use byteorder::{ByteOrder,LittleEndian};
 use errors::{RegError};
 use std::io::Cursor;
+use serde::Serialize;
 
 #[derive(Serialize, Debug, Clone)]
 pub struct SecurityKey {
@@ -14,6 +15,7 @@ pub struct SecurityKey {
     descriptor_size: u32,
     descriptor: SecurityDescriptor
 }
+
 impl SecurityKey {
     pub fn new(buffer: &[u8], offset: u64) -> Result<SecurityKey,RegError> {
         let signature = LittleEndian::read_u16(&buffer[0..2]);
@@ -23,8 +25,9 @@ impl SecurityKey {
         let reference_count = LittleEndian::read_u32(&buffer[12..16]);
         let descriptor_size = LittleEndian::read_u32(&buffer[16..20]);
 
-        let descriptor = SecurityDescriptor::new(
-            Cursor::new(&buffer[20..])
+        let mut cursor = Cursor::new(&buffer[20..]);
+        let descriptor = SecurityDescriptor::from_stream(
+            &mut cursor
         )?;
 
         Ok(

--- a/src/sk.rs
+++ b/src/sk.rs
@@ -1,4 +1,5 @@
 use winstructs::security::{SecurityDescriptor};
+use winstructs::err::Error;
 use byteorder::{ByteOrder,LittleEndian};
 use errors::{RegError};
 use std::io::Cursor;
@@ -26,9 +27,14 @@ impl SecurityKey {
         let descriptor_size = LittleEndian::read_u32(&buffer[16..20]);
 
         let mut cursor = Cursor::new(&buffer[20..]);
-        let descriptor = SecurityDescriptor::from_stream(
+        let descriptor = match SecurityDescriptor::from_stream(
             &mut cursor
-        )?;
+        ) {
+            Ok(descriptor) => descriptor,
+            Err(why) => {
+                return Err(RegError::from(why));
+            }
+        };
 
         Ok(
             SecurityKey {

--- a/src/vk.rs
+++ b/src/vk.rs
@@ -192,6 +192,10 @@ impl ValueKey {
         &self.value_name
     }
 
+    pub fn get_data_type(&self) -> &VkDataType {
+        &self.data_type
+    }
+
     pub fn data_is_resident(&self)->bool {
         if self.data_size >> 31 == 0 {
             false

--- a/src/vk.rs
+++ b/src/vk.rs
@@ -10,6 +10,7 @@ use std::fmt;
 use std::io::Read;
 use std::io::Seek;
 use std::mem::transmute;
+use serde::Serialize;
 
 #[derive(Serialize, Debug, Clone)]
 #[serde(untagged)]


### PR DESCRIPTION
just because the first builds ;-) As soon as @omerbenamram has merged https://github.com/omerbenamram/winstructs/pull/7, we can update Cargo.toml to use the original master branch